### PR TITLE
&SocketAddr -> SocketAddr

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2021, LinkTed
+Copyright (c) 2018-2021, LinkTed, Evan Cameron
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -60,7 +60,7 @@ fn socket_addr_to_string(socket_addr: SocketAddr, default_port: u16) -> String {
 }
 
 /// Encode a `std::net::SocketAddr` into a `std::vec::Vec<u8>`.
-/// If the `socket_addr` hat the same `default_port`
+/// If the `socket_addr` has the same `default_port`
 /// then encode only the `std::net::IpAddr`.
 fn encode_socket_addr(
     buffer: &mut Vec<u8>,


### PR DESCRIPTION
`IpAddr`/`SocketAddr` are all `Copy`, so let's just pass them by value. This is consistent with the std lib and tokio now also I believe.

These are all internal functions so it doesn't really matter that much, but I had already made the change before I remembered that :smile: 

there is a clippy lint for this I believe: https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

edit: looks like it is based on size so this could be a bit subjective